### PR TITLE
Seed to string mapping (bytes to alphabet mapping) now supports groups.

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -2,5 +2,5 @@ seed_length: int = 128
 db_name: str = "pswdmngr.db"
 default_iterations: int = 30
 default_length: int = 16
-default_alphabet: str = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ "
+default_alphabet: str = r"\[abcdefghijklmnopqrstuvwxyz\]\[ABCDEFGHIJKLMNOPQRSTUVWXYZ\]\[0123456789\]\[!\"#$%&'()*+,-./:;<=>?@[]^\\_`{|}~ \]"
 auth_iterations: int = 300000

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,6 @@
 import secrets
 from pathlib import Path
-from typing import Generator
+from typing import Generator, List
 from hashlib import md5
 import src.config as config
 


### PR DESCRIPTION
Groups will not be omitted from the password ("Password MUST contain uppercase, lowercase, numbers, etc."). Syntax for this is ```\[group]\``` in the alphabet string. You are guaranteed that at least one of the character of each group will be present in the final password.